### PR TITLE
Fix FormatException on non-english computers

### DIFF
--- a/Shader Forge/Assets/ShaderForge/Editor/Code/SF_Parser.cs
+++ b/Shader Forge/Assets/ShaderForge/Editor/Code/SF_Parser.cs
@@ -199,7 +199,7 @@ namespace ShaderForge {
 					if( verStr.StartsWith( "v" ) )
 						verStr = verStr.Substring( 1 );
 
-					version = float.Parse(verStr);
+					version = float.Parse(verStr, System.Globalization.CultureInfo.InvariantCulture);
 				}
 				if( shaderData[i].StartsWith( "/*SF_DATA;" ) ) {
 					returnString = shaderData[i].Substring( 10, shaderData[i].Length - 12 ); // Exclude comment markup


### PR DESCRIPTION
On some non-english computers, selecting a shader in the project view will fail to display it in the inspector. This happens when parsing the shader's version, because the locale expects floats to be written with a comma instead of a period.

This small fix just makes sure the float parser always expects a period.